### PR TITLE
Add initial CRD validation

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -2,11 +2,9 @@ scorecard:
   # Setting a global scorecard option
   output: text
   plugins:
-    # `basic` tests configured to test 2 CRs
     - basic:
         cr-manifest:
           - "deploy/crds/infra.watch_v1alpha1_serviceassurance_cr.yaml"
-    # `olm` tests configured to test 2 CRs
     - olm:
         cr-manifest:
           - "deploy/crds/infra.watch_v1alpha1_serviceassurance_cr.yaml"

--- a/deploy/crds/infra.watch_serviceassurances_crd.yaml
+++ b/deploy/crds/infra.watch_serviceassurances_crd.yaml
@@ -10,9 +10,28 @@ spec:
     plural: serviceassurances
     singular: serviceassurance
   scope: Namespaced
+  version: v1alpha1
   subresources:
     status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: Specification of the desired behavior of the Service Assurance Operator.
+          properties:
+            metrics:
+              description: Options related to metrics collection and storage.
+              properties:
+                enabled:
+                  description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
+                  type: boolean
+            events:
+              description: Options related to events collection and storage.
+              properties:
+                enabled:
+                  description: Whether the Service Assurance Operator should enable components related to events collection and storage.
+                  type: boolean

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/infra.watch_serviceassurances_crd.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/infra.watch_serviceassurances_crd.yaml
@@ -17,3 +17,21 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: Specification of the desired behavior of the Service Assurance Operator.
+          properties:
+            metrics:
+              description: Options related to metrics collection and storage.
+              properties:
+                enabled:
+                  description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
+                  type: boolean
+            events:
+              description: Options related to events collection and storage.
+              properties:
+                enabled:
+                  description: Whether the Service Assurance Operator should enable components related to events collection and storage.
+                  type: boolean

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
@@ -41,6 +41,48 @@ spec:
       kind: ServiceAssurance
       name: serviceassurances.infra.watch
       version: v1alpha1
+      resources:
+      - kind: Pods
+        version: v1
+      - kind: ConfigMaps
+        version: v1
+      - kind: ServiceAssurances
+        version: v1alpha1
+      - kind: ReplicaSets
+        version: v1
+      - kind: Deployments
+        version: v1
+      - kind: Deployments
+        version: v1
+      - kind: Services
+        version: v1
+      specDescriptors:
+      - description: Metrics related configuration options
+        displayName: Metrics Configuration Options
+        path: metrics
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:'
+      - description: Events related configuration options
+        displayName: Events Configuration Options
+        path: events
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:'
+      - description: Whether to enable collection and storage components for metrics
+        displayName: Metrics Enabled
+        path: metrics.enabled
+        x-descriptors:
+        - 'urn:alm:descriptor:tectonic.ui:booleanSwitch'
+      - description: Whether to enable collection and storage components for events
+        displayName: Events Enabled
+        path: events.enabled
+        x-descriptors:
+        - 'urn:alm:descriptor:tectonic.ui:booleanSwitch'
+    required:
+    - name: prometheuses.monitoring.coreos.com
+      version: v1
+      kind: Prometheus
+      displayName: Prometheus TSDB
+      description: An instances of the Prometheus time-series database
   description: Service Assurance Operator for monitoring clouds
   displayName: Service Assurance Operator
   install:
@@ -163,9 +205,7 @@ spec:
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
-  keywords:
-  - monitoring
-  - serviceassurance
+  keywords: ['serviceassurance','monitoring']
   links:
   - name: Source Code
     url: https://github.com/redhat-service-assurance/service-assurance-operator


### PR DESCRIPTION
Adds the initial validation for CRD and CSV files. Results in additional
checks for basic and olm scorecard tests passing.