### PR TITLE
Refinement of playbooks prior to alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # service-assurance-operator
-[WIP] Umbrella Operator to instantiate all required components for Service Assurance Framework
+
+Umbrella Operator to instantiate all required components for Service Assurance
+Framework.
+
+## Getting Started
+
+You'll need to do the following steps in order to load the prerequisites for
+deploying to an OpenShift 4.x environment:
+
+* import catalog containing Service Assurance and Smart Gateway Operators via
+  OperatorSource file
+* install the AMQ Certificate Manager Operator before installing Service
+  Assurance Operator
+* install the Service Assurance Operator
+
+## Starting up Service Assurance
+
+In the OperatorHub, select "Service Assurance Operator" and install it. You can
+use the defaults.
+
+Once the Service Assurance Operator is available in the _Installed Operators_
+page, select _Service Assurance Operator_ and select _Create instance_ within
+the _SAF Cluster_ box under _Provided APIs_. Then press _Create_.
+
+## Overriding Default Manifests
+
+The following variables can be passed to a new instance of SAF Cluster (kind:
+ServiceAssurance) via the YAML configuration to override the default manifests
+loaded for you.
+
+* prometheus_manifest
+* elasticsearch_secret_manifest
+* interconnect_manifest
+* elasticsearch_manifest
+* smartgateway_metrics_manifest
+* smartgateway_events_manifest
+* servicemonitor_manifest

--- a/roles/serviceassurance/tasks/_local_signing_authority.yml
+++ b/roles/serviceassurance/tasks/_local_signing_authority.yml
@@ -1,0 +1,66 @@
+# ---
+# Build out initial selfsigning issuer
+# ----
+- name: Create selfsigned Issuer
+  k8s:
+    definition:
+      apiVersion: certmanager.k8s.io/v1alpha1
+      kind: Issuer
+      metadata:
+        name: '{{ meta.namespace }}-selfsigned'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        selfSigned: {}
+
+- name: Create CA certificate
+  k8s:
+    definition:
+      apiVersion: certmanager.k8s.io/v1alpha1
+      kind: Certificate
+      metadata:
+        name: '{{ meta.namespace }}-ca'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        commonName: '{{ meta.namespace }}-ca'
+        isCA: true
+        issuerRef:
+          name: '{{ meta.namespace }}-selfsigned'
+        secretName: '{{ meta.namespace }}-ca'
+
+- name: Create namespace CA Issuer
+  k8s:
+    definition:
+      apiVersion: certmanager.k8s.io/v1alpha1
+      kind: Issuer
+      metadata:
+        name: '{{ meta.namespace }}-ca'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        ca:
+          secretName: '{{ meta.namespace }}-ca'
+
+# ----
+# Setup our certificates for import into ElasticSearch
+# ----
+- name: Setup certificates
+  include_tasks: _setup_certificates.yml
+  loop:
+    - { 'name': elasticsearch, 'commonName': elasticsearch }
+    - { 'name': logging, 'commonName': logging }
+    - { 'name': admin, 'commonName': 'system.admin' }
+
+# ----
+# Get certificates to build out 'elasticsearch' secret as used by ElasticSearch object from ESO
+# ----
+- name: Get CA certificate
+  k8s_facts:
+    api_version: v1
+    kind: Secret
+    name: '{{ meta.namespace }}-ca'
+    namespace: '{{ meta.namespace }}'
+  register: local_ca
+
+- name: Set variable containing CA certificate drilldown files
+  set_fact:
+    secret_local_ca_credentials: "{{ local_ca.resources | first }}"
+

--- a/roles/serviceassurance/tasks/component_certificates.yml
+++ b/roles/serviceassurance/tasks/component_certificates.yml
@@ -1,73 +1,11 @@
-# ---
-# Build out initial selfsigning issuer
-# ----
-- name: Create selfsigned Issuer
-  k8s:
-    definition:
-      apiVersion: certmanager.k8s.io/v1alpha1
-      kind: Issuer
-      metadata:
-        name: '{{ meta.namespace }}-selfsigned'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        selfSigned: {}
-
-- name: Create CA certificate
-  k8s:
-    definition:
-      apiVersion: certmanager.k8s.io/v1alpha1
-      kind: Certificate
-      metadata:
-        name: '{{ meta.namespace }}-ca'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        commonName: '{{ meta.namespace }}-ca'
-        isCA: true
-        issuerRef:
-          name: '{{ meta.namespace }}-selfsigned'
-        secretName: '{{ meta.namespace }}-ca'
-
-- name: Create namespace CA Issuer
-  k8s:
-    definition:
-      apiVersion: certmanager.k8s.io/v1alpha1
-      kind: Issuer
-      metadata:
-        name: '{{ meta.namespace }}-ca'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        ca:
-          secretName: '{{ meta.namespace }}-ca'
-
-# ----
-# Setup our certificates for import into ElasticSearch
-# ----
-- name: Setup certificates
-  include_tasks: _setup_certificates.yml
-  loop:
-    - { 'name': elasticsearch, 'commonName': elasticsearch }
-    - { 'name': logging, 'commonName': logging }
-    - { 'name': admin, 'commonName': 'system.admin' }
-
-# ----
-# Get certificates to build out 'elasticsearch' secret as used by ElasticSearch object from ESO
-# ----
-- name: Get CA certificate
-  k8s_facts:
-    api_version: v1
-    kind: Secret
-    name: '{{ meta.namespace }}-ca'
-    namespace: '{{ meta.namespace }}'
-  register: local_ca
-
-- name: Set variable containing CA certificate drilldown files
-  set_fact:
-    secret_local_ca_credentials: "{{ local_ca.resources | first }}"
+- name: Create local signing authority
+  include_tasks: _local_signing_authority.yml
+  when: elasticsearch_secret_manifest is not defined
 
   # the ElasticSearch Instance is very particular about how this secret is constructed
-- name: Create ElasticSearch Secret
-  k8s:
-    definition:
+- name: Create default ElasticSearch Secret
+  set_fact:
+    elasticsearch_secret_manifest: |
       apiVersion: v1
       kind: Secret
       metadata:
@@ -81,3 +19,8 @@
         "admin-key": "{{ secret_admin_credentials.data['tls.key'] }}"
         "admin-cert": "{{ secret_admin_credentials.data['tls.crt'] }}"
         "admin-ca": "{{ secret_local_ca_credentials.data['ca.crt'] }}"
+
+- name: Create ElasticSearch Secret
+  k8s:
+    definition:
+      '{{ elasticsearch_secret_manifest }}'

--- a/roles/serviceassurance/tasks/component_servicemonitor.yml
+++ b/roles/serviceassurance/tasks/component_servicemonitor.yml
@@ -1,6 +1,6 @@
-- name: Create ServiceMonitor to scrape Smart Gateway
-  k8s:
-    definition:
+- name: Create default Service Monitor manifest
+  set_fact:
+    servicemonitor_manifest: |
       apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:
@@ -28,3 +28,9 @@
         selector:
           matchLabels:
             app: smart-gateway
+  when: servicemonitor_manifest is not defined
+
+- name: Create ServiceMonitor to scrape Smart Gateway
+  k8s:
+    definition:
+      '{{ servicemonitor_manifest }}'

--- a/roles/serviceassurance/tasks/component_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_smartgateway.yml
@@ -1,10 +1,10 @@
-- name: Deploy instance of Smart Gateway
-  k8s:
-    definition:
+- name: Create default Metrics Smart Gateway manifest
+  set_fact:
+    smartgateway_metrics_manifest: |
       apiVersion: smartgateway.infra.watch/v2alpha1
       kind: SmartGateway
       metadata:
-        name: '{{ meta.name }}'
+        name: '{{ meta.name }}-telemetry'
         namespace: '{{ meta.namespace }}'
       spec:
         amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
@@ -12,3 +12,39 @@
         debug: 'true'
         service_type: 'metrics'
         size: 1
+  when: smartgateway_metrics_manifest is not defined
+
+- name: Deploy instance of Smart Gateway for Metrics
+  k8s:
+    definition:
+      '{{ smartgateway_metrics_manifest }}'
+  when: metrics.enabled
+
+- name: Create default Events Smart Gateway manifest
+  set_fact:
+    smartgateway_events_manifest: |
+      apiVersion: smartgateway.infra.watch/v2alpha1
+      kind: SmartGateway
+      metadata:
+        name: '{{ meta.name }}-notification'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        size: 1
+        amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notification'
+        service_type: 'events'
+        debug: 'true'
+        elastic_url: '{{ meta.name }}-elasticsearch.{{ meta.namespace }}.svc.cluster.local:9200'
+        container_image_path: 'quay.io/redhat-service-assurance/smart-gateway:latest'
+        use_tls: 'true'
+        tls_client_cert: /config/certs/admin-cert
+        tls_client_key: /config/certs/admin-key
+        tls_ca_cert: /config/certs/admin-ca
+        tls_server_name: 'elasticsearch.{{ meta.namespace }}.svc.cluster.local'
+        reset_index: 'true'
+  when: smartgateway_events_manifest is not defined
+
+- name: Deploy instance of Smart Gateway for Events
+  k8s:
+    definition:
+      '{{ smartgateway_events_manifest }}'
+  when: events.enabled


### PR DESCRIPTION
Clean up the playbooks and get them in a reasonable shape for an alpha release
that others could use. Intent here is to get things into the first setup that allows
for an override of the various manifests that are created by default. Definition
of a default manifest has been included. Expectation is that the defined manifests
will be adjusted going forward.