### PR TITLE
Clean up some missing functionality

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -1,5 +1,4 @@
 scorecard:
-  # Setting a global scorecard option
   output: text
   plugins:
     - basic:

--- a/deploy/crds/infra.watch_serviceassurances_crd.yaml
+++ b/deploy/crds/infra.watch_serviceassurances_crd.yaml
@@ -20,18 +20,56 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Metadata definition for the ServiceAssurance object
+          type: object
         spec:
           description: Specification of the desired behavior of the Service Assurance Operator.
           properties:
-            metrics:
-              description: Options related to metrics collection and storage.
-              properties:
-                enabled:
-                  description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
-                  type: boolean
-            events:
-              description: Options related to events collection and storage.
-              properties:
-                enabled:
-                  description: Whether the Service Assurance Operator should enable components related to events collection and storage.
-                  type: boolean
+            metricsEnabled:
+              description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
+              type: boolean
+            eventsEnabled:
+              description: Whether the Service Assurance Operator should enable components related to events collection and storage.
+              type: boolean
+            prometheusStorageClass:
+              description: Storage class name used for Prometheus PVC
+              type: string
+            prometheusStorageResources:
+              description: Storage resource definition for Prometheus
+              type: string
+            prometheusStorageSelector:
+              description: Storage selector definition for Prometheus
+              type: string
+            prometheusPvcStorageRequest:
+              description: PVC storage requested size for Prometheus
+        status:
+          description: Status results of an instance of Service Assurance
+          properties:
+            conditions:
+              description: The resulting conditions when a Service Assurance is instantiated
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  reason:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                type: object
+              type: array
+          type: object
+
+# vim: set tabstop=2 shiftwidth=2 expandtab ft=yaml:

--- a/deploy/crds/infra.watch_v1alpha1_serviceassurance_cr.yaml
+++ b/deploy/crds/infra.watch_v1alpha1_serviceassurance_cr.yaml
@@ -1,10 +1,8 @@
 apiVersion: infra.watch/v1alpha1
 kind: ServiceAssurance
 metadata:
-  name: cloud1
+  name: saf-default
 spec:
-  metrics:
-    enabled: true
-  events:
-    enabled: false
+  metricsEnabled: true
+  eventsEnabled: false
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/infra.watch_serviceassurances_crd.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/infra.watch_serviceassurances_crd.yaml
@@ -20,18 +20,56 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Metadata definition for the ServiceAssurance object
+          type: object
         spec:
           description: Specification of the desired behavior of the Service Assurance Operator.
           properties:
-            metrics:
-              description: Options related to metrics collection and storage.
-              properties:
-                enabled:
-                  description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
-                  type: boolean
-            events:
-              description: Options related to events collection and storage.
-              properties:
-                enabled:
-                  description: Whether the Service Assurance Operator should enable components related to events collection and storage.
-                  type: boolean
+            metricsEnabled:
+              description: Whether the Service Assurance Operator should enable components related to metrics collection and storage.
+              type: boolean
+            eventsEnabled:
+              description: Whether the Service Assurance Operator should enable components related to events collection and storage.
+              type: boolean
+            prometheusStorageClass:
+              description: Storage class name used for Prometheus PVC
+              type: string
+            prometheusStorageResources:
+              description: Storage resource definition for Prometheus
+              type: string
+            prometheusStorageSelector:
+              description: Storage selector definition for Prometheus
+              type: string
+            prometheusPvcStorageRequest:
+              description: PVC storage requested size for Prometheus
+        status:
+          description: Status results of an instance of Service Assurance
+          properties:
+            conditions:
+              description: The resulting conditions when a Service Assurance is instantiated
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  reason:
+                    type: string
+                  lastTransitionTime:
+                    type: string
+                type: object
+              type: array
+          type: object
+
+# vim: set tabstop=2 shiftwidth=2 expandtab ft=yaml:

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
@@ -8,15 +8,11 @@ metadata:
           "apiVersion": "infra.watch/v1alpha1",
           "kind": "ServiceAssurance",
           "metadata": {
-            "name": "cloud1"
+            "name": "saf-default"
           },
           "spec": {
-            "events": {
-              "enabled": false
-            },
-            "metrics": {
-              "enabled": true
-            }
+            "eventsEnabled": false,
+            "metricsEnabled": true
           }
         }
       ]
@@ -60,26 +56,27 @@ spec:
         name: ""
         version: v1
       specDescriptors:
-      - description: Metrics related configuration options
-        displayName: Metrics Configuration Options
-        path: metrics
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:'
-      - description: Events related configuration options
-        displayName: Events Configuration Options
-        path: events
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:'
       - description: Whether to enable collection and storage components for metrics
         displayName: Metrics Enabled
-        path: metrics.enabled
+        path: metricsEnabled
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:booleanSwitch
       - description: Whether to enable collection and storage components for events
         displayName: Events Enabled
-        path: events.enabled
+        path: eventsEnabled
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:booleanSwitch
+      - displayName: Size of PV request for Prometheus storage. Add your unit to the
+          end (i.e. M (Megabytes), G (Gigabytes), etc) such as '20G'.
+        path: prometheusPvcStorageRequest
+        x-descriptors:
+        - urn:alm:descriptor:tectonic.ui:text
+      statusDescriptors:
+      - description: Status conditions of the ServiceAssurance object creation
+        displayName: Status
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:tectonic.ui:statusConditions
       version: v1alpha1
     required:
     - description: A declaration of a required Certificate

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
@@ -66,8 +66,9 @@ spec:
         path: eventsEnabled
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:booleanSwitch
-      - displayName: Size of PV request for Prometheus storage. Add your unit to the
-          end (i.e. M (Megabytes), G (Gigabytes), etc) such as '20G'.
+      - description: Size of PV request for Prometheus storage. Add your unit to the
+          end (i.e. M (Megabytes), G (Gigabytes), etc) such as "20G".
+        displayName: Prometheus Storage Size
         path: prometheusPvcStorageRequest
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:text

--- a/roles/serviceassurance/defaults/main.yml
+++ b/roles/serviceassurance/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
-metrics:
-  enabled: true
-events:
-  enabled: false
+# set default enablement
+metrics_enabled: true
+events_enabled: false
+
+# default values
+prometheus_storage_class: ""
+prometheus_storage_resources: {}
+prometheus_storage_selector: {}
+prometheus_pvc_storage_request: 20G
+
 # vim: set ft=yaml shiftwidth=2 tabstop=2 expandtab:

--- a/roles/serviceassurance/tasks/component_prometheus.yml
+++ b/roles/serviceassurance/tasks/component_prometheus.yml
@@ -16,6 +16,15 @@
         serviceMonitorSelector:
           matchLabels:
             app: smart-gateway
+        storage:
+          class: {{ prometheus_storage_class }}
+          resources: {{ prometheus_storage_resources }}
+          selector: {{ prometheus_storage_selector }}
+          volumeClaimTemplate:
+            spec:
+              resources:
+                requests:
+                  storage: {{ prometheus_pvc_storage_request }}
   when: prometheus_manifest is not defined
 
 - name: Create an instance of Prometheus

--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -9,7 +9,7 @@
         namespace: '{{ meta.namespace }}'
       spec:
         deploymentPlan:
-          size: 2
+          size: 1
           role: interior
           livenessPort: 8888
           placement: Any
@@ -45,6 +45,13 @@
           - expose: true
             http: true
             port: 8672
+        sslProfiles:
+          - caCert: saf-demo-interconnect-openstack-ca
+            credentials: saf-demo-interconnect-openstack-credentials
+            generateCaCert: true
+            generateCredentials: true
+            name: openstack
+
   when: interconnect_manifest is not defined
 
 - name: Create QDR instance

--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -13,7 +13,6 @@
           role: interior
           livenessPort: 8888
           placement: Any
-          resources: {}
         addresses:
           - distribution: closest
             prefix: closest
@@ -58,7 +57,6 @@
             generateCredentials: true
             mutualAuth: true
             name: inter-router
-        users: {{ meta.name }}-interconnect-users
   when: interconnect_manifest is not defined
 
 - name: Create QDR instance

--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -13,6 +13,7 @@
           role: interior
           livenessPort: 8888
           placement: Any
+          resources: {}
         addresses:
           - distribution: closest
             prefix: closest
@@ -51,7 +52,6 @@
             generateCaCert: true
             generateCredentials: true
             name: openstack
-
   when: interconnect_manifest is not defined
 
 - name: Create QDR instance

--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -47,11 +47,18 @@
             http: true
             port: 8672
         sslProfiles:
-          - caCert: saf-demo-interconnect-openstack-ca
-            credentials: saf-demo-interconnect-openstack-credentials
+          - caCert: {{ meta.name }}-interconnect-openstack-ca
+            credentials: {{ meta.name }}-interconnect-openstack-credentials
             generateCaCert: true
             generateCredentials: true
             name: openstack
+          - caCert: {{ meta.name }}-interconnect-inter-router-ca
+            credentials: {{ meta.name }}-interconnect-inter-router-credentials
+            generateCaCert: true
+            generateCredentials: true
+            mutualAuth: true
+            name: inter-router
+        users: {{ meta.name }}-interconnect-users
   when: interconnect_manifest is not defined
 
 - name: Create QDR instance

--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -32,7 +32,7 @@
           - expose: true
             host: 0.0.0.0
             port: 5671
-            saslMechanisms: EXTERNAL
+            saslMechanisms: ANONYMOUS
             sslProfile: openstack
         interRouterListeners:
           - authenticatePeer: true

--- a/roles/serviceassurance/tasks/main.yml
+++ b/roles/serviceassurance/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Execute default tasks when metrics are requested to be enabled
   include_tasks: sa_metrics.yml
-  when: metrics.enabled
+  when: metrics_enabled
 
 - name: Execute default tasks when events are requested to be enabled
   include_tasks: sa_events.yml
-  when: events.enabled
+  when: events_enabled


### PR DESCRIPTION
Go through the Operator and clean up some missing functionality that we previously
had in the tech preview deployment. Primary items that have been added are:

* request PVC for Prometheus instance (default 20G)
* create the sslProfile and credentials required for clients to connect
  to the AMQ Interconnect route
* reduce the default router number from 2 to 1
* adjust default metrics/events enable flags to better align to
  how the Ansible Operator prefers parameters to be passed (less error prone)
* update CRD to match the new parameters available

One additional note about the CRD update. Changes in the CSV have also
been updated to reflect the new CRD changes. While doing that, the operator-sdk
scorecard was run and with better knowledge about descriptors, all changes
were made to allow for the scorecard test to pass fully.

Closes #2