### PR TITLE
Update statusDescriptors so it is valid again

### DIFF
--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
@@ -73,11 +73,36 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:text
       statusDescriptors:
-      - description: Status conditions of the ServiceAssurance object creation
-        displayName: Status
-        path: conditions
-        x-descriptors:
-        - urn:alm:descriptor:tectonic.ui:statusConditions
+        - description: Tasks changed
+          displayName: Changed
+          path: conditions[0].ansibleResult.changed
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - description: Tasks last completed
+          displayName: Last Completed
+          path: conditions[0].ansibleResult.completion
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Tasks failed
+          displayName: Failed
+          path: conditions[0].ansibleResult.failures
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - description: Tasks OK
+          displayName: OK
+          path: conditions[0].ansibleResult.ok
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - description: Tasks skipped
+          displayName: Skipped
+          path: conditions[0].ansibleResult.skipped
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+            - urn:alm:descriptor:com.tectonic.ui:number
       version: v1alpha1
     required:
     - description: A declaration of a required Certificate


### PR DESCRIPTION
Unfortunately I might have found a bug or usecase that is not yet documented. Our status.conditions
output is a list, and so far I have not found many examples of the status output being a list.

There does exist an option in the watches.yaml for manageStatus: false that would allow us to
manage the status ourselves. That might ultimately be the solution here, however is a task
for another day.

This change is to give us some information about what happened in the run, and to allow for
the status to show up. Unforunately at this point it will result in the operator-sdk
scorecard from passing fully, but that's more a nice-to-have option at this point.

Closes #17