### PR TITLE
Allow for Events/ElasticSearch to be setup

### DIFF
--- a/roles/serviceassurance/tasks/_local_signing_authority.yml
+++ b/roles/serviceassurance/tasks/_local_signing_authority.yml
@@ -64,3 +64,20 @@
   set_fact:
     secret_local_ca_credentials: "{{ local_ca.resources | first }}"
 
+  # the ElasticSearch Instance is very particular about how this secret is constructed
+- name: Create default ElasticSearch Secret
+  set_fact:
+    elasticsearch_secret_manifest: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: elasticsearch
+        namespace: "{{ meta.namespace }}"
+      data:
+        "elasticsearch.key": "{{ secret_elasticsearch_credentials.data['tls.key'] }}"
+        "elasticsearch.crt": "{{ secret_elasticsearch_credentials.data['tls.crt'] }}"
+        "logging-es.key": "{{ secret_logging_credentials.data['tls.key'] }}"
+        "logging-es.crt": "{{ secret_logging_credentials.data['tls.crt'] }}"
+        "admin-key": "{{ secret_admin_credentials.data['tls.key'] }}"
+        "admin-cert": "{{ secret_admin_credentials.data['tls.crt'] }}"
+        "admin-ca": "{{ secret_local_ca_credentials.data['ca.crt'] }}"

--- a/roles/serviceassurance/tasks/component_certificates.yml
+++ b/roles/serviceassurance/tasks/component_certificates.yml
@@ -2,24 +2,6 @@
   include_tasks: _local_signing_authority.yml
   when: elasticsearch_secret_manifest is not defined
 
-  # the ElasticSearch Instance is very particular about how this secret is constructed
-- name: Create default ElasticSearch Secret
-  set_fact:
-    elasticsearch_secret_manifest: |
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: elasticsearch
-        namespace: "{{ meta.namespace }}"
-      data:
-        "elasticsearch.key": "{{ secret_elasticsearch_credentials.data['tls.key'] }}"
-        "elasticsearch.crt": "{{ secret_elasticsearch_credentials.data['tls.crt'] }}"
-        "logging-es.key": "{{ secret_logging_credentials.data['tls.key'] }}"
-        "logging-es.crt": "{{ secret_logging_credentials.data['tls.crt'] }}"
-        "admin-key": "{{ secret_admin_credentials.data['tls.key'] }}"
-        "admin-cert": "{{ secret_admin_credentials.data['tls.crt'] }}"
-        "admin-ca": "{{ secret_local_ca_credentials.data['ca.crt'] }}"
-
 - name: Create ElasticSearch Secret
   k8s:
     definition:

--- a/roles/serviceassurance/tasks/component_elasticsearch.yml
+++ b/roles/serviceassurance/tasks/component_elasticsearch.yml
@@ -9,14 +9,12 @@
       spec:
         managementState: Managed
         nodeSpec:
-          image: >-
-            registry.redhat.io/openshift4/ose-logging-elasticsearch5@sha256:a671fe2339f38dc58795e45de4a4310d12efb8ff476b729086badb4900b9c7ba
+          image: 'registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.8'
           resources:
             limits:
               memory: 4Gi
             requests:
               memory: 1Gi
-        redundancyPolicy: ZeroRedundancy
         nodes:
           - nodeCount: 1
             roles:
@@ -26,6 +24,7 @@
             storage:
               storageClassName: ""
               size: 10Gi
+        redundancyPolicy: ZeroRedundancy
   when: elasticsearch_manifest is not defined
 
 - name: Create an instance of ElasticSearch

--- a/roles/serviceassurance/tasks/component_elasticsearch.yml
+++ b/roles/serviceassurance/tasks/component_elasticsearch.yml
@@ -9,12 +9,13 @@
       spec:
         managementState: Managed
         nodeSpec:
-          image: 'registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.8'
+          image: registry.redhat.io/openshift4/ose-logging-elasticsearch5:v4.2.8
           resources:
             limits:
               memory: 4Gi
             requests:
               memory: 1Gi
+        redundancyPolicy: ZeroRedundancy
         nodes:
           - nodeCount: 1
             roles:
@@ -24,7 +25,6 @@
             storage:
               storageClassName: ""
               size: 10Gi
-        redundancyPolicy: ZeroRedundancy
   when: elasticsearch_manifest is not defined
 
 - name: Create an instance of ElasticSearch

--- a/roles/serviceassurance/tasks/component_events_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_events_smartgateway.yml
@@ -11,7 +11,7 @@
         amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notification'
         service_type: 'events'
         debug: 'true'
-        elastic_url: '{{ meta.name }}-elasticsearch.{{ meta.namespace }}.svc.cluster.local:9200'
+        elastic_url: 'https://elasticsearch.{{ meta.namespace }}.svc.cluster.local:9200'
         container_image_path: 'quay.io/redhat-service-assurance/smart-gateway:latest'
         use_tls: 'true'
         tls_client_cert: /config/certs/admin-cert

--- a/roles/serviceassurance/tasks/main.yml
+++ b/roles/serviceassurance/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Create QDR instance
+  include_tasks: component_qdr.yml
+
 - name: Execute default tasks when metrics are requested to be enabled
   include_tasks: sa_metrics.yml
   when: metrics_enabled

--- a/roles/serviceassurance/tasks/sa_metrics.yml
+++ b/roles/serviceassurance/tasks/sa_metrics.yml
@@ -1,8 +1,4 @@
 ---
-# create QDR instance
-- name: Create QDR instance
-  include_tasks: component_qdr.yml
-
 # create Prometheus instance
 - name: Create Prometheus instance
   include_tasks: component_prometheus.yml


### PR DESCRIPTION
Requires a workaround (you need to supply the `elasticsearch` secret via the `elasticsearchSecretManifest` override in the `ServiceAssurance` manifest), but at least we can make some progress for testing events support.