### PR TITLE
Fixing events URL

### DIFF
--- a/roles/serviceassurance/tasks/component_events_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_events_smartgateway.yml
@@ -8,7 +8,7 @@
         namespace: '{{ meta.namespace }}'
       spec:
         size: 1
-        amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notification'
+        amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
         service_type: 'events'
         debug: 'true'
         elastic_url: 'https://elasticsearch.{{ meta.namespace }}.svc.cluster.local:9200'


### PR DESCRIPTION
I noticed this mismatch while trying to get events working in my HA testing. The URL here is wrong.

Here are the some places that suggest it should be "notify" instead:
* https://redhat-service-assurance.github.io/saf-documentation/#configuring-red-hat-openstack-platform-overcloud-for-saf-events_completing-the-saf-configuration
* https://github.com/redhat-service-assurance/telemetry-framework/blob/master/tests/performance-test/deploy/config/minimal-collectd.conf#L16
* https://github.com/redhat-service-assurance/telemetry-framework/blob/master/tests/smoketest/minimal-collectd.conf.template#L21