### PR TITLE
Turn off SG debug by default

### DIFF
--- a/roles/serviceassurance/tasks/component_events_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_events_smartgateway.yml
@@ -10,7 +10,7 @@
         size: 1
         amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/notify'
         service_type: 'events'
-        debug: 'true'
+        debug: 'false'
         elastic_url: 'https://elasticsearch.{{ meta.namespace }}.svc.cluster.local:9200'
         container_image_path: 'quay.io/redhat-service-assurance/smart-gateway:latest'
         use_tls: 'true'

--- a/roles/serviceassurance/tasks/component_metrics_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_metrics_smartgateway.yml
@@ -9,7 +9,7 @@
       spec:
         amqp_url: '{{ meta.name }}-interconnect.{{ meta.namespace }}.svc.cluster.local:5672/collectd/telemetry'
         container_image_path: 'quay.io/redhat-service-assurance/smart-gateway:latest'
-        debug: 'true'
+        debug: 'false'
         service_type: 'metrics'
         size: 1
         prefetch: 15000


### PR DESCRIPTION
* Debug logging of every message is waaaaay too noisy
* I've also observed serious performance degredation when running in debug
  * Total throughput is lower
  * Serving the prometheus scrape page takes longer