### PR TITLE
Migrate to non-versioned container registry

### DIFF
--- a/build/push_app2quay.sh
+++ b/build/push_app2quay.sh
@@ -16,5 +16,8 @@ AUTH_TOKEN=$(curl -sH "Content-Type: application/json" \
 -XPOST https://quay.io/cnr/api/v1/users/login \
 -d '{"user": {"username": "'"${USERNAME}"'", "password": "'"${PASSWORD}"'"}}' | jq -r '.token')
 
-operator-courier push "./deploy/olm-catalog/service-assurance-operator" "redhat-service-assurance" "service-assurance-operator" "${CSV_VERSION}-${UNIXDATE}" "${AUTH_TOKEN}"
+# The application registry name and the container registry name can not be the same on quay.io. Same as we do with the smart-gateway-operator we remove the first
+# instance of the hyphen for the application registry (serviceassurance-operator). For the container registry we match the git repository name (service-assurance-operator).
+operator-courier push "./deploy/olm-catalog/service-assurance-operator" "redhat-service-assurance" "serviceassurance-operator" "${CSV_VERSION}-${UNIXDATE}" "${AUTH_TOKEN}"
+
 # vim: set ft=bash:

--- a/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/0.1.0/service-assurance-operator.v0.1.0.clusterserviceversion.yaml
@@ -73,36 +73,36 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:tectonic.ui:text
       statusDescriptors:
-        - description: Tasks changed
-          displayName: Changed
-          path: conditions[0].ansibleResult.changed
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
-            - urn:alm:descriptor:com.tectonic.ui:number
-        - description: Tasks last completed
-          displayName: Last Completed
-          path: conditions[0].ansibleResult.completion
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
-            - urn:alm:descriptor:com.tectonic.ui:text
-        - description: Tasks failed
-          displayName: Failed
-          path: conditions[0].ansibleResult.failures
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
-            - urn:alm:descriptor:com.tectonic.ui:number
-        - description: Tasks OK
-          displayName: OK
-          path: conditions[0].ansibleResult.ok
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
-            - urn:alm:descriptor:com.tectonic.ui:number
-        - description: Tasks skipped
-          displayName: Skipped
-          path: conditions[0].ansibleResult.skipped
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
-            - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tasks changed
+        displayName: Changed
+        path: conditions[0].ansibleResult.changed
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tasks last completed
+        displayName: Last Completed
+        path: conditions[0].ansibleResult.completion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tasks failed
+        displayName: Failed
+        path: conditions[0].ansibleResult.failures
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tasks OK
+        displayName: OK
+        path: conditions[0].ansibleResult.ok
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tasks skipped
+        displayName: Skipped
+        path: conditions[0].ansibleResult.skipped
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:ansibleResults
+        - urn:alm:descriptor:com.tectonic.ui:number
       version: v1alpha1
     required:
     - description: A declaration of a required Certificate
@@ -155,7 +155,7 @@ spec:
                 - /usr/local/bin/ao-logs
                 - /tmp/ansible-operator/runner
                 - stdout
-                image: quay.io/redhat-service-assurance/service-assurance-operator.0.1.0:latest
+                image: quay.io/redhat-service-assurance/service-assurance-operator:latest
                 imagePullPolicy: Always
                 name: ansible
                 resources: {}
@@ -176,7 +176,7 @@ spec:
                   value: service-assurance-operator
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                image: quay.io/redhat-service-assurance/service-assurance-operator.0.1.0:latest
+                image: quay.io/redhat-service-assurance/service-assurance-operator:latest
                 imagePullPolicy: Always
                 name: operator
                 resources: {}

--- a/deploy/olm-catalog/service-assurance-operator/service-assurance-operator.package.yaml
+++ b/deploy/olm-catalog/service-assurance-operator/service-assurance-operator.package.yaml
@@ -2,4 +2,4 @@ channels:
 - currentCSV: service-assurance-operator.v0.1.0
   name: alpha
 defaultChannel: alpha
-packageName: service-assurance-operator
+packageName: serviceassurance-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,14 +19,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: quay.io/redhat-service-assurance/service-assurance-operator.0.1.0:latest
+          image: quay.io/redhat-service-assurance/service-assurance-operator:latest
           imagePullPolicy: Always
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
-          image: quay.io/redhat-service-assurance/service-assurance-operator.0.1.0:latest
+          image: quay.io/redhat-service-assurance/service-assurance-operator:latest
           imagePullPolicy: Always
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner


### PR DESCRIPTION
Migrate the container images to a registry that doesn't include the CSV version
in the name. To do this, need to remove the old application registry of the
same desired name to serviceassurance-operator in order to free up the use of
service-assurance-operator for the container registry.

(The naming convensions used match our naming for delivery of the Smart Gateway
Operator.)

Script for pushing latest CSV into the application registry has been updated to
match the new name and validated to have worked. The deploy/operator.yaml file
has been adjusted and the operator-sdk olm-catalog gen-csv has been executed to
get the
generated olm-catalog contents up to date.