### PR TITLE
Set Interconnect default config for OSP

### DIFF
--- a/roles/serviceassurance/tasks/component_qdr.yml
+++ b/roles/serviceassurance/tasks/component_qdr.yml
@@ -26,18 +26,17 @@
             prefix: broadcast
           - distribution: multicast
             prefix: collectd
-        edgeListeners:
-          - expose: true
-            host: 0.0.0.0
-            port: 5671
-            saslMechanisms: ANONYMOUS
-            sslProfile: openstack
         interRouterListeners:
           - authenticatePeer: true
             expose: true
             port: 55671
             saslMechanisms: EXTERNAL
             sslProfile: inter-router
+          - expose: true
+            host: 0.0.0.0
+            port: 5671
+            saslMechanisms: ANONYMOUS
+            sslProfile: openstack
         listeners:
           - port: 5672
           - expose: true


### PR DESCRIPTION
Set the default configuration for Interconnect to be compatible with OSP13 and 16
connections.

**BLOCKED** _do not merge_

Working on external end to end testing to validate exactly what kind of server side connection we are going to expose for a default `enable-saf.yaml` environment in OSP.