### PR TITLE
Set reset_index to false so SG doesn't delete all events

### DIFF
--- a/roles/serviceassurance/tasks/component_events_smartgateway.yml
+++ b/roles/serviceassurance/tasks/component_events_smartgateway.yml
@@ -18,7 +18,7 @@
         tls_client_key: /config/certs/admin-key
         tls_ca_cert: /config/certs/admin-ca
         tls_server_name: 'elasticsearch.{{ meta.namespace }}.svc.cluster.local'
-        reset_index: 'true'
+        reset_index: 'false'
   when: smartgateway_events_manifest is not defined
 
 - name: Deploy instance of Smart Gateway for Events


### PR DESCRIPTION
This is an **untested** change (by me)

Closes https://github.com/redhat-service-assurance/service-assurance-operator/issues/32