### PR TITLE
Fixed defaults and docs for OSP16 test script

### DIFF
--- a/tests/infrared/13/infrared-openstack.sh
+++ b/tests/infrared/13/infrared-openstack.sh
@@ -8,9 +8,16 @@ set -e
 VIRTHOST=${VIRTHOST:-my.big.hypervisor.net}
 AMQP_HOST=${AMQP_HOST:-$(oc get route -l application=qdr-white -o jsonpath='{.items[0].spec.host}')}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
-VM_IMAGE="${VM_IMAGE:-http://download-node-02.eng.bos.redhat.com/released/RHEL-7/7.7/Server/x86_64/images/rhel-guest-image-7.7-261.x86_64.qcow2}"
-OSP_BUILD="${OSP_BUILD:-7.7-latest}"
 NTP_SERVER="${NTP_SERVER:-10.35.255.6}"
+
+VM_IMAGE_URL_PATH="${VM_IMAGE_URL_PATH:-http://127.0.0.1/my_image_location/}"
+if [ "${VM_IMAGE_URL_PATH}" = "http://127.0.0.1/my_image_location/" -a -z "${VM_IMAGE}" ]; then
+    echo "Please provide a VM_IMAGE_URL_PATH or VM_IMAGE"
+    exit 1
+fi
+# Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
+VM_IMAGE="${VM_IMAGE:-${VM_IMAGE_URL_PATH}/rhel-guest-image-7.7-261.x86_64.qcow2}"
+OSP_BUILD="${OSP_BUILD:-7.7-latest}"
 
 infrared virsh \
     -vv \

--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -9,9 +9,11 @@ VIRTHOST=${VIRTHOST:-localhost}
 AMQP_HOST=${AMQP_HOST:-saf-default-interconnect-5671-sa-telemetry.apps-crc.testing}
 AMQP_PORT=${AMQP_PORT:-443}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
-VM_IMAGE="${VM_IMAGE:-http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.1/333/images/rhel-guest-image-8.1-333.x86_64.qcow2}"
-OSP_BUILD="${OSP_BUILD:-latest-RHOS_TRUNK-16-RHEL-8.1}"
 NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"
+# Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
+VM_IMAGE="${VM_IMAGE:-http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.1/333/images/rhel-guest-image-8.1-333.x86_64.qcow2}"
+OSP_BUILD="${OSP_BUILD:-RHOS_TRUNK-16.0-RHEL-8-20200131.n.0}"
+
 
 infrared virsh \
     -vv \

--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -11,8 +11,8 @@ AMQP_PORT=${AMQP_PORT:-443}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
 NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"
 # Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
-VM_IMAGE="${VM_IMAGE:-http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.1/333/images/rhel-guest-image-8.1-333.x86_64.qcow2}"
-OSP_BUILD="${OSP_BUILD:-RHOS_TRUNK-16.0-RHEL-8-20200131.n.0}"
+VM_IMAGE="${VM_IMAGE:-http://download.eng.bos.redhat.com/brewroot/packages/rhel-guest-image/8.1/413/images/rhel-guest-image-8.1-413.x86_64.qcow2}"
+OSP_BUILD="${OSP_BUILD:-RHOS_TRUNK-16.0-RHEL-8-20200204.n.1}"
 
 
 infrared virsh \

--- a/tests/infrared/16/infrared-openstack.sh
+++ b/tests/infrared/16/infrared-openstack.sh
@@ -10,10 +10,15 @@ AMQP_HOST=${AMQP_HOST:-saf-default-interconnect-5671-sa-telemetry.apps-crc.testi
 AMQP_PORT=${AMQP_PORT:-443}
 SSH_KEY="${SSH_KEY:-${HOME}/.ssh/id_rsa}"
 NTP_SERVER="${NTP_SERVER:-clock.redhat.com,10.5.27.10,10.11.160.238}"
-# Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
-VM_IMAGE="${VM_IMAGE:-http://download.eng.bos.redhat.com/brewroot/packages/rhel-guest-image/8.1/413/images/rhel-guest-image-8.1-413.x86_64.qcow2}"
-OSP_BUILD="${OSP_BUILD:-RHOS_TRUNK-16.0-RHEL-8-20200204.n.1}"
 
+VM_IMAGE_URL_PATH="${VM_IMAGE_URL_PATH:-http://127.0.0.1/my_image_location/}"
+if [ "${VM_IMAGE_URL_PATH}" = "http://127.0.0.1/my_image_location/" -a -z "${VM_IMAGE}" ]; then
+    echo "Please provide a VM_IMAGE_URL_PATH or VM_IMAGE"
+    exit 1
+fi
+# Recommend these default to tested immutable dentifiers where possible, pass "latest" style ids via environment if you want them
+VM_IMAGE="${VM_IMAGE:-${VM_IMAGE_URL_PATH}/rhel-guest-image-8.1-413.x86_64.qcow2}"
+OSP_BUILD="${OSP_BUILD:-RHOS_TRUNK-16.0-RHEL-8-20200204.n.1}"
 
 infrared virsh \
     -vv \

--- a/tests/infrared/README.md
+++ b/tests/infrared/README.md
@@ -6,12 +6,8 @@ to an SAF instance all on one (large) baremetal machine.
 ## Usage
 
 1. Have `ir --version` working
-1. Have `oc` tools working and pointed at a deploy SAF namespace
 1. Set VIRTHOST and have key based SSH access to root@$VIRTHOST
-1. (optional - not yet fully working) Run `minishift-saf.sh` to install OCP + SAF on $VIRTHOST
-    * Ensure the smoketest is passing before proceeding
-1. (optional) Set AMQP_HOST to point to your SAF
-    * Default is taken from the route if `oc` is pointing to your SAF namespace
+1. Set AMQP_HOST and AMQP_PORT
 1. Run `infrared-openstack.sh` to install OSP on $VIRTHOST
 (Cry when it fails; try to pick up where it left off)
 
@@ -32,13 +28,11 @@ You should be seeing samples for both compute-0 and controller-0
 Tested with the following versions:
 
 * infrared
-  * 2.0.1.dev3506 (ansible-2.7.12, python-2.7.5)
-* oc
-  * v3.11.0+0cbc58b
+  * 2.0.1.dev3952 (ansible-2.7.16, python-2.7.5)
 * "Virthost"
   * RHEL 7.6
 
 ## TODO
 * Stamp out the few remaining IP addresses and RH internal defaults
-* Get the minishift on VIRTHOST scenario working
+* Get the crc on VIRTHOST scenario working
 * Automated verification script


### PR DESCRIPTION
* Adjusted OCP_BUILD default and documented infrared version

I would like to re-test this using the OSP16 GA compose on the officially
supported 8.1.1 guest image (both apparently built yesterday) but I haven't
had a chance yet. This at least works again.