### PR TITLE
Fix operator-sdk version check

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,7 @@ REL=$(dirname "$0"); source "${REL}/metadata.sh"
 cd "${REL}/.."
 
 echo -e "\n* [info] Checking operator-sdk version\n"
-SDK_VERSION=$(operator-sdk version | cut -d '"' -f2)
+SDK_VERSION=$(operator-sdk version | cut -d '"' -f2 | cut -d '-' -f1)
 if [ "${SDK_VERSION}" != "${REQUIRED_OPERATOR_SDK_VERSION}" ]; then
     echo -e "* [error] Wrong operator-sdk version. Wanted ${REQUIRED_OPERATOR_SDK_VERSION}, Got: ${SDK_VERSION}\n";
     exit 1


### PR DESCRIPTION
My operator-sdk version returns as a string similar to v0.12.0-47-g94a0669c
which breaks the check in the build.sh script. I added another pipe into cut to
only check everything to the left of the build ID