### PR TITLE
Update smoke tests to work with ECK

### DIFF
--- a/build/build_ci.sh
+++ b/build/build_ci.sh
@@ -37,10 +37,19 @@ echo -e "\n* [info] Waiting for QDR deployment to complete\n"
 until timeout 300 oc rollout status deployment.apps/saf-default-interconnect; do sleep 3; done
 echo -e "\n* [info] Waiting for prometheus deployment to complete\n"
 until timeout 300 oc rollout status statefulset.apps/prometheus-saf-default; do sleep 3; done
+echo -e "\n* [info] Waiting for elasticsearch deployment to complete \n"
+while true; do
+    ES_READY=$(oc get statefulsets elasticsearch-es-default -ogo-template='{{ .status.readyReplicas }}') || continue
+    if [ "${ES_READY}" == "1" ]; then
+        break
+    fi
+    sleep 3
+done
 echo -e "\n* [info] Waiting for alertmanager deployment to complete\n"
 until timeout 300 oc rollout status statefulset.apps/alertmanager-saf-default; do sleep 3; done
 echo -e "\n* [info] Waiting for smart-gateway deployment to complete\n"
 until timeout 300 oc rollout status deploymentconfig.apps.openshift.io/saf-default-telemetry-smartgateway; do sleep 3; done
+until timeout 300 oc rollout status deploymentconfig.apps.openshift.io/saf-default-notification-smartgateway; do sleep 3; done
 echo -e "\n* [info] Waiting for all pods to show Ready/Complete\n"
 while oc get pods | tail -n +2 | grep -v -E 'Running|Completed'; do
     sleep 3

--- a/deploy/configs/default.bash
+++ b/deploy/configs/default.bash
@@ -5,4 +5,4 @@ metadata:
   namespace: ${OCP_PROJECT}
 spec:
   metricsEnabled: true
-  eventsEnabled: false"
+  eventsEnabled: true"

--- a/deploy/quickstart.sh
+++ b/deploy/quickstart.sh
@@ -5,7 +5,33 @@ QUICKSTART_CONFIG=${QUICKSTART_CONFIG:-configs/default.bash}
 source "${REL}/${QUICKSTART_CONFIG}"
 
 oc new-project "${OCP_PROJECT}"
-oc create -f - <<EOF
+oc apply -f - <<EOF
+
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+spec:
+  disableAllDefaultSources: true
+  sources:
+  - disabled: false
+    name: certified-operators
+  - disabled: false
+    name: redhat-operators
+
+---
+
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: ${OCP_PROJECT}-og
+  namespace: ${OCP_PROJECT}
+spec:
+  targetNamespaces:
+  -  ${OCP_PROJECT}
+
+---
+
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:
@@ -17,6 +43,19 @@ spec:
   registryNamespace: redhat-service-assurance
   displayName: Service Assurance Operators
   publisher: Red Hat (CloudOps)
+
+---
+
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/operator-framework/upstream-community-operators:latest
+  displayName: OperatorHub.io Operators
+  publisher: OperatorHub.io
 
 ---
 
@@ -35,14 +74,18 @@ spec:
 
 ---
 
-apiVersion: operators.coreos.com/v1alpha2
-kind: OperatorGroup
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
 metadata:
-  name: ${OCP_PROJECT}-og
+  name: elastic-cloud-eck
   namespace: ${OCP_PROJECT}
 spec:
-  targetNamespaces:
-  -  ${OCP_PROJECT}
+  channel: stable
+  installPlanApproval: Automatic
+  name: elastic-cloud-eck
+  source: operatorhubio-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: elastic-cloud-eck.v1.0.0
 
 ---
 

--- a/deploy/remove_saf.sh
+++ b/deploy/remove_saf.sh
@@ -11,6 +11,25 @@ oc delete project "${OCP_PROJECT}"
 # Our custom OperatorSource
 oc delete OperatorSource redhat-service-assurance-operators -n openshift-marketplace
 
+# Revert our OperatorHub.io catalog for default built-in Community Operators
+oc delete CatalogSource operatorhubio-operators -n openshift-marketplace
+
+oc apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+spec:
+  disableAllDefaultSources: true
+  sources:
+  - disabled: false
+    name: certified-operators
+  - disabled: false
+    name: redhat-operators
+  - disabled: false
+    name: community-operators
+EOF
+
 # SAF CRDs
 oc get crd | grep infra.watch | cut -d ' ' -f 1 | xargs oc delete crd
 

--- a/tests/smoketest/smoketest.sh
+++ b/tests/smoketest/smoketest.sh
@@ -18,19 +18,20 @@ for ((i=1; i<=NUMCLOUDS; i++)); do
   NAME="smoke${i}"
   CLOUDNAMES+=(${NAME})
 done
+REL=$(dirname "$0")
 
 echo "*** [INFO] Getting ElasticSearch authentication password"
 ELASTICSEARCH_AUTH_PASS=$(oc get secret elasticsearch-es-elastic-user -ogo-template='{{ .data.elastic | base64decode }}')
 
 echo "*** [INFO] Creating configmaps..."
 oc delete configmap/saf-smoketest-collectd-config configmap/saf-smoketest-entrypoint-script job/saf-smoketest || true
-oc create configmap saf-smoketest-collectd-config --from-file ./minimal-collectd.conf.template
-oc create configmap saf-smoketest-entrypoint-script --from-file ./smoketest_entrypoint.sh
+oc create configmap saf-smoketest-collectd-config --from-file ${REL}/minimal-collectd.conf.template
+oc create configmap saf-smoketest-entrypoint-script --from-file ${REL}/smoketest_entrypoint.sh
 
 echo "*** [INFO] Creating smoketest jobs..."
 oc delete job -l app=saf-smoketest
 for NAME in "${CLOUDNAMES[@]}"; do
-    oc create -f <(sed -e "s/<<CLOUDNAME>>/${NAME}/;s/<<ELASTICSEARCH_AUTH_PASS>>/${ELASTICSEARCH_AUTH_PASS}/" smoketest_job.yaml.template)
+    oc create -f <(sed -e "s/<<CLOUDNAME>>/${NAME}/;s/<<ELASTICSEARCH_AUTH_PASS>>/${ELASTICSEARCH_AUTH_PASS}/" ${REL}/smoketest_job.yaml.template)
 done
 
 # Trying to find a less brittle test than a timeout

--- a/tests/smoketest/smoketest_entrypoint.sh
+++ b/tests/smoketest/smoketest_entrypoint.sh
@@ -44,31 +44,21 @@ grep -E '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","end
 metrics_result=$?
 
 echo "Get documents for this test from ElasticSearch..."
-DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "https://${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'
-{
-  "size": 0,
-  "terminate_after": 1,
+DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "https://${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
   "query": {
     "bool": {
-      "must": {
-        "match_phrase": {
-          "labels.instance": {
-            "query": "saf-smoketest-'"${CLOUDNAME}"'*"
-          }
-        }
-      },
-      "filter": {
-        "range" : {
-          "startsAt" : {
-            "gte" : "now-1m",
-            "lt" :  "now"
-           }
-         }
-      }
+      "must": [
+        { "match": { "labels.instance":   "'${CLOUDNAME}'" }}
+      ],
+      "filter": [
+        { "range" : { "startsAt" : { "gte" : "now-1m", "lt" : "now" } } }
+      ]
     }
   }
-}' | python -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['_shards']['total'])")
-echo ${DOCUMENT_HITS}
+}' | python -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
+
+echo "Found ${DOCUMENT_HITS} documents"
+
 echo; echo
 
 # check if we got documents back for this test

--- a/tests/smoketest/smoketest_entrypoint.sh
+++ b/tests/smoketest/smoketest_entrypoint.sh
@@ -11,9 +11,9 @@ POD=$(hostname)
 # Render our config template
 sed -e "s/<<CLOUDNAME>>/${CLOUDNAME}/" /etc/minimal-collectd.conf.template > /tmp/collectd.conf
 
-echo "My pod is: ${POD}"
+echo "*** [INFO] My pod is: ${POD}"
 
-echo "Using this collectd.conf:"
+echo "*** [INFO] Using this collectd.conf:"
 cat /tmp/collectd.conf
 
 # Run collectd in foreground mode to generate some metrics
@@ -23,19 +23,20 @@ cat /tmp/collectd.conf
 retries=3
 until [ $retries -eq 0 ] || grep "Initialization complete, entering read-loop" /tmp/collectd_output; do
   retries=$((retries-1))
-  echo "Sleeping for 3 seconds waiting for collectd to enter read-loop"
+  echo "*** [INFO] Sleeping for 3 seconds waiting for collectd to enter read-loop"
   sleep 3
 done
 
 # Sleeping to collect 1m of actual metrics
+echo "*** [INFO] Sleeping for 60 seconds to collect a minute of metrics and events"
 sleep 60
 
-echo "List of metric names for debugging..."
+echo "*** [INFO] List of metric names for debugging..."
 curl -g "${PROMETHEUS}/api/v1/label/__name__/values" 2>&2 | tee /tmp/label_names
 echo; echo
 
 # Checks that the metrics actually appear in prometheus
-echo "Checking for recent CPU metrics..."
+echo "*** [INFO] Checking for recent CPU metrics..."
 curl -g "${PROMETHEUS}/api/v1/query?" --data-urlencode 'query=sa_collectd_cpu_total{cpu="0",type="user",service="saf-default-telemetry-smartgateway",exported_instance="'"${POD}"'"}[1m]' 2>&2 | tee /tmp/query_output
 echo; echo
 
@@ -43,22 +44,19 @@ echo; echo
 grep -E '"result":\[{"metric":{"__name__":"sa_collectd_cpu_total","cpu":"0","endpoint":"prom-http","exported_instance":"'"${POD}"'","service":"saf-default-telemetry-smartgateway","type":"user"},"values":\[\[.+,".+"\]' /tmp/query_output
 metrics_result=$?
 
-echo "Get documents for this test from ElasticSearch..."
+echo "*** [INFO] Get documents for this test from ElasticSearch..."
 DOCUMENT_HITS=$(curl -sk -u "elastic:${ELASTICSEARCH_AUTH_PASS}" -X GET "https://${ELASTICSEARCH}/_search" -H 'Content-Type: application/json' -d'{
   "query": {
     "bool": {
-      "must": [
-        { "match": { "labels.instance":   "'${CLOUDNAME}'" }}
-      ],
       "filter": [
+        { "term" : { "labels.instance" : { "value" : "'${CLOUDNAME}'", "boost" : 1.0 } } },
         { "range" : { "startsAt" : { "gte" : "now-1m", "lt" : "now" } } }
       ]
     }
   }
 }' | python -c "import sys, json; parsed = json.load(sys.stdin); print(parsed['hits']['total']['value'])")
 
-echo "Found ${DOCUMENT_HITS} documents"
-
+echo "*** [INFO] Found ${DOCUMENT_HITS} documents"
 echo; echo
 
 # check if we got documents back for this test
@@ -68,7 +66,9 @@ if [ "$DOCUMENT_HITS" -gt "0" ]; then
 fi
 
 if [ "$metrics_result" = "0" ] && [ "$events_result" = "0" ]; then
+    echo "*** [INFO] Testing completed with success"
     exit 0
 else
+    echo "*** [INFO] Testing completed without success"
     exit 1
 fi

--- a/tests/smoketest/smoketest_job.yaml.template
+++ b/tests/smoketest/smoketest_job.yaml.template
@@ -20,6 +20,8 @@ spec:
         env:
         - name: CLOUDNAME
           value: <<CLOUDNAME>>
+        - name: ELASTICSEARCH_AUTH_PASS
+          value: <<ELASTICSEARCH_AUTH_PASS>>
         volumeMounts:
         - name: collectd-config
           mountPath: /etc/minimal-collectd.conf.template
@@ -27,8 +29,6 @@ spec:
         - name: entrypoint-script
           mountPath: /smoketest_entrypoint.sh
           subPath: smoketest_entrypoint.sh
-        - mountPath: /certificates
-          name: certificates
       volumes:
       - name: collectd-config
         configMap:
@@ -37,7 +37,3 @@ spec:
         configMap:
           name: saf-smoketest-entrypoint-script
           defaultMode: 0555
-      - name: certificates
-        secret:
-          secretName: elasticsearch
-          defaultMode: 420


### PR DESCRIPTION
The smoke tests that cover events are currently non-operational after
a lift-and-replace of the Operator managing our ElasticSearch instances.

This change addresses the change from the ECL ElasticSearch
Operator to use of the OperatorHub.io provided Elastic Cloud on
Kubernetes (ECK) Operator.