### PR TITLE
CI running smoketest

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-echo "Passing CI with this thorough test"
-

--- a/ci.yml
+++ b/ci.yml
@@ -1,6 +1,4 @@
 script:
-        - cd build
-        - echo $PATH
         - export HOME=$(dirname "$PWD")
         - oc login -u kubeadmin -p BdTY8-Vra64-gD3cI-dAPS6 --insecure-skip-tls-verify=true https://api.crc.testing:6443
         - IMAGE_BUILD_ARGS="--storage-driver vfs" ./build_ci.sh

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,12 @@
+script:
+        - cd build
+        - echo $PATH
+        - export HOME=$(dirname "$PWD")
+        - oc login -u kubeadmin -p BdTY8-Vra64-gD3cI-dAPS6 --insecure-skip-tls-verify=true https://api.crc.testing:6443
+        - IMAGE_BUILD_ARGS="--storage-driver vfs" ./build_ci.sh
+        - cd ../tests/smoketest 
+        - ./smoketest.sh
+after_script:
+        - cd deploy/ 
+        - export HOME=$(dirname "$PWD")
+        - ./remove_saf.sh

--- a/ci.yml
+++ b/ci.yml
@@ -1,8 +1,8 @@
 script:
         - export HOME=$(dirname "$PWD")
         - oc login -u kubeadmin -p BdTY8-Vra64-gD3cI-dAPS6 --insecure-skip-tls-verify=true https://api.crc.testing:6443
-        - IMAGE_BUILD_ARGS="--storage-driver vfs" ./build_ci.sh
-        - cd ../tests/smoketest 
+        - IMAGE_BUILD_ARGS="--storage-driver vfs" ./build/build_ci.sh
+        - cd ./tests/smoketest 
         - ./smoketest.sh
 after_script:
         - cd deploy/ 


### PR DESCRIPTION
`ci.yml` specifies the build, smoketest, and tear down of the SAO image based on updates in whatever branch contains this file. For the CI Bot to run tests on a branch, this file must be included in the same format as in this PR. Results of this process are posted to a gist that can be accessed by selecting the `details` link when hovering over the commit status:

![image](https://user-images.githubusercontent.com/41337120/74194352-118b5180-4c27-11ea-8d56-9fa0df41256d.png)

The CI Bot is currently running on Pradeep's local machine in a CRC. As such, this script must unfortunately have machine specific login commands for CRC for the time being.

Commit statuses are based on the exit status of scripts run in the `script` section of `ci.yml`. The `after_scrip` section allows for clean up scripts to execute without interfering with test statuses (it's important to cleanup everything created by the script sections because the CI Bot is running on a persistent CRC with limited resources).